### PR TITLE
Fixes setting hostname, uniq stemcell download, error handling, and getting a new token

### DIFF
--- a/lib/ops_manager/api/opsman.rb
+++ b/lib/ops_manager/api/opsman.rb
@@ -176,13 +176,13 @@ class OpsManager
 
       private
       def token_issuer
-        @token_issuer = CF::UAA::TokenIssuer.new(
+        @token_issuer ||= CF::UAA::TokenIssuer.new(
           "https://#{target}/uaa", 'opsman', nil, skip_ssl_validation: true )
       end
 
       def access_token
         token = get_token
-        @access_token ||= token ? token.info['access_token'] : nil
+        @access_token = token ? token.info['access_token'] : nil
       end
 
       def authorization_header

--- a/lib/ops_manager/api/opsman.rb
+++ b/lib/ops_manager/api/opsman.rb
@@ -138,11 +138,11 @@ class OpsManager
               when '503' ; sleep(60)
             end
           rescue CF::UAA::BadResponse
-            puts "Caught a BadResponse error.  Handling it"
+            puts "Caught a BadResponse error.  Sleeping 60 seconds."
             sleep(60)
             next
           rescue
-            puts "Caught an unidentified error.  Handling it"
+            puts "Caught an unidentified error.  Sleeping 60 seconds."
             sleep(60)
             next
           end

--- a/lib/ops_manager/appliance_deployment.rb
+++ b/lib/ops_manager/appliance_deployment.rb
@@ -24,7 +24,9 @@ class OpsManager::ApplianceDeployment
     OpsManager.set_conf(:pivnet_token, config.pivnet_token)
 
     self.extend(OpsManager::Deployments::Vsphere)
-
+      if config.has_key?('hostname') then
+        OpsManager.set_conf(:target, config.hostname)
+      end
     case
     when current_version.empty?
       puts "No OpsManager deployed at #{config.ip}. Deploying ...".green
@@ -112,7 +114,7 @@ class OpsManager::ApplianceDeployment
   def download_current_stemcells
     puts "Downloading existing stemcells ...".green
     FileUtils.mkdir_p current_stemcell_dir
-    list_current_stemcells.each do |stemcell_version|
+    list_current_stemcells.uniq.each do |stemcell_version|
       release_id = find_stemcell_release(stemcell_version)
       accept_product_release_eula('stemcells', release_id )
       file_id, file_name = find_stemcell_file(release_id, /vsphere/)


### PR DESCRIPTION
This PR resolves a few issues:

- Forces the client to use a hostname if it exists in all cases vs. only when deploying a new OVA.
- uniq's the stemcell download operation so that it doesn't pull download duplicate stemcells
- Adds some error handling to import_stemcell().  The loop was error'ing out post Ops Manager upgrade with `CF::UAA::BadResponse` and not looping as intended.
- Forces the client to get a new access token each time instead of reusing one if it already exists.  This fixes an issue post Ops Manager upgrade where the client was attempting to use the token provided by previous Ops Manager UAA which is no longer valid.